### PR TITLE
change S3_BUCKET_NAME to AWS_S3_BUCKET_NAME

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -49,7 +49,7 @@ objects:
                 name: hpf-pypi-insights-s3
           - name: FLASK_LOGGING_LEVEL
             value: ${FLASK_LOGGING_LEVEL}
-          - name: S3_BUCKET_NAME
+          - name: AWS_S3_BUCKET_NAME
             valueFrom:
               secretKeyRef:
                 key: bucket


### PR DESCRIPTION
f8a-pypi-insights environment should have 'AWS_S3_BUCKET_NAME' variable for bucket as emr_api payload overwrites this variable.