### PR TITLE
change S3_BUCKET_NAME to AWS_S3_BUCKET_NAME

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -49,7 +49,7 @@ objects:
                 name: hpf-pypi-insights-s3
           - name: FLASK_LOGGING_LEVEL
             value: ${FLASK_LOGGING_LEVEL}
-          - name: S3_BUCKET_NAME
+          - name: AWS_S3_BUCKET_NAME
             valueFrom:
               secretKeyRef:
                 key: bucket

--- a/src/config/cloud_constants.py
+++ b/src/config/cloud_constants.py
@@ -24,7 +24,7 @@ import numpy as np
 USE_CLOUD_SERVICES = os.environ.get('USE_CLOUD_SERVICES', 'true') == 'true'
 AWS_S3_ACCESS_KEY_ID = os.environ.get('AWS_S3_ACCESS_KEY_ID', '')
 AWS_S3_SECRET_KEY_ID = os.environ.get('AWS_S3_SECRET_ACCESS_KEY', '')
-S3_BUCKET_NAME = os.environ.get('S3_BUCKET_NAME', 'hpf-insights')
+AWS_S3_BUCKET_NAME = os.environ.get('AWS_S3_BUCKET_NAME', 'hpf-insights')
 AWS_S3_ENDPOINT_URL = os.environ.get('AWS_S3_ENDPOINT_URL', '')
 MIN_CONFIDENCE_SCORE = np.float32(int(os.environ.get('MIN_CONFIDENCE_SCORE', 30)))
 GITHUB_TOKEN = os.environ.get('GITHUB_TOKEN', '')

--- a/training/train.py
+++ b/training/train.py
@@ -32,7 +32,7 @@ import subprocess
 from src.config.path_constants import (PACKAGE_TO_ID_MAP,
                                        MANIFEST_TO_ID_MAP, MANIFEST_PATH, HPF_MODEL_PATH, ECOSYSTEM,
                                        HYPERPARAMETERS_PATH, MODEL_VERSION)
-from src.config.cloud_constants import (S3_BUCKET_NAME,
+from src.config.cloud_constants import (AWS_S3_BUCKET_NAME,
                                         AWS_S3_SECRET_KEY_ID, AWS_S3_ACCESS_KEY_ID, GITHUB_TOKEN)
 
 logging.basicConfig()
@@ -44,13 +44,13 @@ bq_validator = BQValidation()
 
 def load_s3():  # pragma: no cover
     """Create connection s3."""
-    s3_object = AmazonS3(bucket_name=S3_BUCKET_NAME,
+    s3_object = AmazonS3(bucket_name=AWS_S3_BUCKET_NAME,
                          aws_access_key_id=AWS_S3_ACCESS_KEY_ID,
                          aws_secret_access_key=AWS_S3_SECRET_KEY_ID)
 
     s3_object.connect()
     if s3_object.is_connected():
-        _logger.info("S3 connection established for {} bucket".format(S3_BUCKET_NAME))
+        _logger.info("S3 connection established for {} bucket".format(AWS_S3_BUCKET_NAME))
         return s3_object
 
     raise Exception("S3 Connection Failed")


### PR DESCRIPTION
In f8a-pypi-insights env vars, S3_BUCKET_NAME needs to change to AWS_S3_BUCKET_NAME as latter is replaced by emr_api payload.
S3_BUCKET_NAME var in train.py is also changed to bring in sync with maven and npm repos.


